### PR TITLE
Prevent segmentation fault which is caused by null wavelength

### DIFF
--- a/libcrystfel/src/image.c
+++ b/libcrystfel/src/image.c
@@ -800,7 +800,7 @@ static int set_image_parameters(struct image *image,
                                 const DataTemplate *dtempl)
 {
 	double wl_val;
-	if ( convert_float(dtempl->wavelength_from, &wl_val) ) {
+	if ( dtempl->wavelength_from && convert_float(dtempl->wavelength_from, &wl_val) ) {
 
 		/* Not a literal value - try header */
 		if ( image_read_header_float(image,


### PR DESCRIPTION
Somehow, while using data used in the [tutorial](https://www.desy.de/~twhite/crystfel/tutorial.html), the `wavelength_from` primitive of `DataTemplate` is coming `NULL`. It causes SIGSEGV signal in `strtod` function which is used in `libcrystfel/src/utils.c:329`.

If we use this commit, the image is displayed, and the statement prevents SIGSEGV.